### PR TITLE
require pouchdb-promise.default

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var createBulkDocsWrapper = require("pouchdb-bulkdocs-wrapper");
 var PouchPluginError = require("pouchdb-plugin-error");
 
 var uuid = require("random-uuid-v4");
-var Promise = require("pouchdb-promise");
+var Promise = require("pouchdb-promise").default;
 
 function oldDoc(db, id) {
   return db.get(id, {revs: true}).catch(function () {


### PR DESCRIPTION
On install I get v6.4.3 of pouchdb-promise which is `default exporting` the Promise. With webpack >5 it is required to use the `require('pouchdb-promise').default` to be able to use it.